### PR TITLE
Add support for generating fake IDs for Custom Object Share records

### DIFF
--- a/moxygen/main/default/classes/utilities/id-generator/fflib_IDGenerator.cls
+++ b/moxygen/main/default/classes/utilities/id-generator/fflib_IDGenerator.cls
@@ -37,9 +37,18 @@ public with sharing class fflib_IDGenerator {
     /**
      * Generate a fake Salesforce Id for the given SObjectType
      */
-    public static Id generate(Schema.SObjectType sobjectType) {
-        String keyPrefix = sobjectType.getDescribe().getKeyPrefix();
+    public static Id generate(Schema.SObjectType sObjectType) {
+        Schema.DescribeSObjectResult sObjectDescribe = sObjectType.getDescribe();
+        String keyPrefix = sObjectDescribe.getKeyPrefix();
         fakeIdCount++;
+
+        // Use the Parent SObjectType key prefix for Custom Object share records
+        if (keyPrefix == null) {
+            Schema.DescribeFieldResult parentIdFieldDescribe = sObjectDescribe.fields.getMap().get('ParentId').getDescribe();
+            Schema.SObjectType parentSObjectType = parentIdFieldDescribe.getReferenceTo()[0];
+            Schema.DescribeSObjectResult parentSObjectDescribe = parentSObjectType.getDescribe();
+            keyPrefix = parentSObjectDescribe.getKeyPrefix();
+        }
 
         String fakeIdPrefix = ID_PATTERN.substring(
             0,


### PR DESCRIPTION
Custom Object share records (Custom_Object__Share) do not have key prefixes.

This change uses the Parent SObject type of the Custom Object share record to generate a fake ID.