### PR TITLE
Use DataStore.isSoftDeleted for SObjects that do not have an IsDelete…

### DIFF
--- a/moxygen/main/default/classes/database/soql-engine/mock-soql-handlers/MockRecordQueryHandler.cls
+++ b/moxygen/main/default/classes/database/soql-engine/mock-soql-handlers/MockRecordQueryHandler.cls
@@ -111,11 +111,17 @@ public with sharing class MockRecordQueryHandler extends MockSOQLHandler {
             );
         }
 
+        Boolean hasIsDeletedField = sot.getDescribe().fields.getMap().containsKey('IsDeleted');
+
         List<SObject> records = new List<sObject>();
 
         // process the query, whether it's a count, aggregate, or regular query
         for (sObject databaseRecord : mockObjects.values()) {
-            if (databaseRecord.get('IsDeleted') == true) {
+            if (hasIsDeletedField) {
+                if (databaseRecord.get('IsDeleted') == true) {
+                    continue;
+                }
+            } else if (DataStore.isSoftDeleted((Id)databaseRecord.get('Id'))) {
                 continue;
             }
 


### PR DESCRIPTION
…d field

`Group` is an example SObject that does not have an `IsDeleted` field.